### PR TITLE
brainsignals/neural_simulations.py

### DIFF
--- a/brainsignals/neural_simulations.py
+++ b/brainsignals/neural_simulations.py
@@ -417,13 +417,13 @@ def return_stick_cell(tstop, dt):
     }
     celldef()
 
-    Ra = 150.
-    cm = 1.
     Rm = 30000.
 
     forall {
         insert pas // 'pas' for passive, 'hh' for Hodgkin-Huxley
         g_pas = 1 / Rm
+        Ra = 150.
+        cm = 1.
         }
     """)
     cell_params = {
@@ -486,15 +486,17 @@ def return_ball_and_stick_cell(tstop, dt, apic_diam=2):
     }
     celldef()
 
-    Ra = 150.
-    cm = 1.
+
     Rm = 30000.
 
     forall {
         insert pas // 'pas' for passive, 'hh' for Hodgkin-Huxley
         g_pas = 1 / Rm
+        Ra = 150.
+        cm = 1.
         }
     """ % (apic_diam, apic_diam))
+
     cell_params = {
                 'morphology': h.all,
                 'delete_sections': False,
@@ -556,15 +558,13 @@ def return_two_comp_cell(tstop, dt):
     }
     celldef()
 
-    Ra = 150.
-    cm = 1.
     Rm = 30000.
 
     forall {
         insert pas // 'pas' for passive, 'hh' for Hodgkin-Huxley
         g_pas = 1 / Rm
-        Ra = Ra
-        cm = cm
+        Ra = 150.
+        cm = 1.
         }
     """)
     cell_params = {

--- a/brainsignals/version.py
+++ b/brainsignals/version.py
@@ -1,5 +1,5 @@
 _MAJOR = "1"
-_MINOR = "0"
+_MINOR = "1"
 # On main and in a nightly release the patch should be one ahead of the last
 # released build.
 _PATCH = "0"


### PR DESCRIPTION
Closes Issue #19 

Changes proposed in this pull request:
- I moved Ra and cm inside the `forall` block in `return_ball_and_stick_cell`. For consistency, the same was done for `return_stick_cell` and `return_two_comp_cell`, although in these two cases it does not affect the cell model.
- I bumped the version number. 


